### PR TITLE
Add TXT test files section

### DIFF
--- a/app/arquivos-testes/txt/download/layout.tsx
+++ b/app/arquivos-testes/txt/download/layout.tsx
@@ -1,0 +1,7 @@
+export default function DownloadLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    return children;
+} 

--- a/app/arquivos-testes/txt/download/page.tsx
+++ b/app/arquivos-testes/txt/download/page.tsx
@@ -1,0 +1,76 @@
+import { Metadata } from "next";
+import { Suspense } from "react";
+import Header from "@/components/layout/Header";
+import InfoSection from "@/components/layout/template/InfoSection";
+import LoadingResult from "@/components/layout/LoadingResult";
+import DownloadClient from "@/components/layout/files/DownloadClient";
+
+export const metadata: Metadata = {
+    title: "Download Concluído | Arquivos .TXT para Teste - TW Tools",
+    description: "Confirmação de download de arquivo .TXT de teste",
+};
+
+const infoItems = [
+    {
+        title: "Sobre o Download",
+        type: "info" as const,
+        content: (<p>O download do arquivo foi iniciado com sucesso. Verifique sua pasta de downloads.</p>)
+    },
+    {
+        title: "Próximos Passos",
+        type: "usage" as const,
+        content: (<p>✓ Verifique se o arquivo foi baixado corretamente<br />✓ Teste o arquivo em seu ambiente<br />✓ Verifique a integridade do arquivo</p>)
+    },
+    {
+        title: "Dicas de Uso",
+        type: "features" as const,
+        content: (<p>✓ Mantenha os arquivos em uma pasta de teste separada<br />✓ Não use em ambientes de produção<br />✓ Faça backup antes de testar</p>)
+    },
+    {
+        title: "Aviso Legal",
+        type: "legal" as const,
+        content: (<p>Estes arquivos são fornecidos apenas para fins de teste. Não utilize em ambientes de produção ou para fins comerciais.</p>)
+    }
+]
+
+export default function DownloadPage() {
+    const breadcrumbs = [
+        {
+            name: 'Arquivos de Teste',
+            href: '/arquivos-testes',
+            current: false
+        },
+        {
+            name: '.TXT',
+            href: '/arquivos-testes/txt',
+            current: false
+        },
+        {
+            name: 'Download',
+            href: '/arquivos-testes/txt/download',
+            current: true
+        }
+    ];
+
+    return (
+        <>
+            <Header
+                miniTitle="Download Concluído"
+                title="Arquivo .TXT Baixado com Sucesso"
+                description="Seu arquivo .TXT de teste foi baixado com sucesso"
+                breadcrumbs={breadcrumbs}
+            />
+            <Suspense fallback={<LoadingResult />}>
+                <DownloadClient
+                    title="Download Concluído"
+                    description="O arquivo foi baixado com sucesso"
+                    infoTitle="Informações Importantes"
+                    infoMessage="Verifique sua pasta de downloads para encontrar o arquivo"
+                    backPath="/arquivos-testes"
+                    buttonText="Voltar para Lista de Arquivos"
+                />
+            </Suspense>
+            <InfoSection items={infoItems} />
+        </>
+    );
+} 

--- a/app/arquivos-testes/txt/page.tsx
+++ b/app/arquivos-testes/txt/page.tsx
@@ -1,0 +1,60 @@
+import { Metadata } from "next";
+import Header from "@/components/layout/Header";
+import InfoSection from "@/components/layout/template/InfoSection";
+import TXTTestFiles from "@/components/layout/files/TXTTestFiles";
+
+export const metadata: Metadata = {
+    title: "Arquivos .TXT para Teste | TW Tools",
+    description: "Baixe arquivos .TXT de teste para suas necessidades de desenvolvimento e testes",
+};
+
+const infoItems = [
+    {
+        title: "Sobre os Arquivos",
+        type: "info" as const,
+        content: (<p>Esta seção oferece uma variedade de arquivos TXT para teste, úteis para desenvolvimento e validação de sistemas.</p>)
+    },
+    {
+        title: "Uso Recomendado",
+        type: "usage" as const,
+        content: (<p>✓ Testes de upload de arquivos<br />✓ Validação de processamento de TXT<br />✓ Testes de integração<br />✓ Verificação de compatibilidade</p>)
+    },
+    {
+        title: "Diferenciais",
+        type: "features" as const,
+        content: (<p>✓ Arquivos de diferentes tamanhos<br />✓ TXT com diferentes características<br />✓ Formatos padronizados<br />✓ Arquivos otimizados para teste</p>)
+    },
+    {
+        title: "Aviso Legal",
+        type: "legal" as const,
+        content: (<p>Estes arquivos são fornecidos apenas para fins de teste. Não utilize em ambientes de produção ou para fins comerciais.</p>)
+    }
+]
+
+export default function TXTTestFilesPage() {
+    const breadcrumbs = [
+        {
+            name: 'Arquivos de Teste',
+            href: '/arquivos-testes',
+            current: false
+        },
+        {
+            name: '.TXT',
+            href: '/arquivos-testes/txt',
+            current: true
+        }
+    ];
+
+    return (
+        <>
+            <Header
+                miniTitle="Arquivos de Teste"
+                title="Arquivos .TXT para Teste"
+                description="Baixe arquivos .TXT de teste para suas necessidades de desenvolvimento e testes"
+                breadcrumbs={breadcrumbs}
+            />
+            <TXTTestFiles />
+            <InfoSection items={infoItems} />
+        </>
+    )
+} 

--- a/public/download/txt/file01.txt
+++ b/public/download/txt/file01.txt
@@ -1,0 +1,1 @@
+Exemplo de arquivo TXT para teste.

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -95,6 +95,7 @@ export const arquivosRoutes = {
     { name: 'Arquivos .XLSX', href: '/arquivos-testes/xlsx' },
     { name: 'Arquivos .CSV', href: '/arquivos-testes/csv' },
     { name: 'Arquivos .JSON', href: '/arquivos-testes/json' },
+    { name: 'Arquivos .TXT', href: '/arquivos-testes/txt' },
     { name: 'Todos os Arquivos', href: '/arquivos-testes', shortcutHidden: true },
   ],
 }

--- a/src/components/layout/files/TXTTestFiles.tsx
+++ b/src/components/layout/files/TXTTestFiles.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import Button from '@/components/ui/Button'
+import FormPage from '../template/FormPage'
+
+const txtFiles = [
+    {
+        id: 'sample1',
+        name: 'TXT de Exemplo 1',
+        description: 'TXT simples com dados de exemplo',
+        size: '0.10 MB',
+        path: '/download/txt/file01.txt'
+    },
+]
+
+export default function TXTTestFiles() {
+    const router = useRouter()
+
+    const handleDownload = (file: typeof txtFiles[0]) => {
+        router.push(`/arquivos-testes/txt/download`)
+        setTimeout(() => {
+            window.open(file.path, '_blank')
+        }, 100)
+    }
+    
+    return (
+        <FormPage
+            title="Arquivos TXT Disponíveis"
+            description="Selecione um arquivo para download"
+        >
+            <div className="px-4 py-6 sm:p-8">
+                <div className="grid grid-cols-1 gap-6">
+                    {txtFiles.map((file) => (
+                        <div
+                            key={file.id}
+                            className="flex items-center justify-between p-4 border-main-900 border rounded-lg hover:bg-gray-50"
+                        >
+                            <div>
+                                <h3 className="text-lg font-medium text-gray-900">{file.name}</h3>
+                                <p className="mt-1 text-sm text-gray-500">{file.description}</p>
+                                <p className="mt-1 text-sm text-gray-500">Tamanho: {file.size}</p>
+                            </div>
+
+                            <Button
+                                onClick={() => handleDownload(file)}
+                            >
+                                Download
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </FormPage>
+    )
+} 


### PR DESCRIPTION
## Summary
- add TXT test files page and download flow
- provide TXT sample file
- link TXT section in sidebar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689cab2e94308322a6e93c973f764afc