### PR TITLE
Add ZIP, RAR, and 7Z test file pages

### DIFF
--- a/app/arquivos-testes/7z/download/page.tsx
+++ b/app/arquivos-testes/7z/download/page.tsx
@@ -1,0 +1,76 @@
+import { Metadata } from "next";
+import { Suspense } from "react";
+import Header from "@/components/layout/Header";
+import InfoSection from "@/components/layout/template/InfoSection";
+import LoadingResult from "@/components/layout/LoadingResult";
+import DownloadClient from "@/components/layout/files/DownloadClient";
+
+export const metadata: Metadata = {
+    title: "Download Concluído | Arquivos .7Z para Teste - TW Tools",
+    description: "Confirmação de download de arquivo .7Z de teste",
+};
+
+const infoItems = [
+    {
+        title: "Sobre o Download",
+        type: "info" as const,
+        content: (<p>O download do arquivo foi iniciado com sucesso. Verifique sua pasta de downloads.</p>)
+    },
+    {
+        title: "Próximos Passos",
+        type: "usage" as const,
+        content: (<p>✓ Verifique se o arquivo foi baixado corretamente<br />✓ Teste o arquivo em seu ambiente<br />✓ Verifique a integridade do arquivo</p>)
+    },
+    {
+        title: "Dicas de Uso",
+        type: "features" as const,
+        content: (<p>✓ Mantenha os arquivos em uma pasta de teste separada<br />✓ Não use em ambientes de produção<br />✓ Faça backup antes de testar</p>)
+    },
+    {
+        title: "Aviso Legal",
+        type: "legal" as const,
+        content: (<p>Estes arquivos são fornecidos apenas para fins de teste. Não utilize em ambientes de produção ou para fins comerciais.</p>)
+    }
+]
+
+export default function DownloadPage() {
+    const breadcrumbs = [
+        {
+            name: 'Arquivos de Teste',
+            href: '/arquivos-testes',
+            current: false
+        },
+        {
+            name: '.7Z',
+            href: '/arquivos-testes/7z',
+            current: false
+        },
+        {
+            name: 'Download',
+            href: '/arquivos-testes/7z/download',
+            current: true
+        }
+    ];
+
+    return (
+        <>
+            <Header
+                miniTitle="Download Concluído"
+                title="Arquivo .7Z Baixado com Sucesso"
+                description="Seu arquivo .7Z de teste foi baixado com sucesso"
+                breadcrumbs={breadcrumbs}
+            />
+            <Suspense fallback={<LoadingResult />}>
+                <DownloadClient
+                    title="Download Concluído"
+                    description="O arquivo foi baixado com sucesso"
+                    infoTitle="Informações Importantes"
+                    infoMessage="Verifique sua pasta de downloads para encontrar o arquivo"
+                    backPath="/arquivos-testes"
+                    buttonText="Voltar para Lista de Arquivos"
+                />
+            </Suspense>
+            <InfoSection items={infoItems} />
+        </>
+    );
+}

--- a/app/arquivos-testes/7z/page.tsx
+++ b/app/arquivos-testes/7z/page.tsx
@@ -1,0 +1,60 @@
+import { Metadata } from "next";
+import Header from "@/components/layout/Header";
+import InfoSection from "@/components/layout/template/InfoSection";
+import SevenZTestFiles from "@/components/layout/files/SevenZTestFiles";
+
+export const metadata: Metadata = {
+    title: "Arquivos .7Z para Teste | TW Tools",
+    description: "Baixe arquivos .7Z de teste para suas necessidades de desenvolvimento e testes",
+};
+
+const infoItems = [
+    {
+        title: "Sobre os Arquivos",
+        type: "info" as const,
+        content: (<p>Esta seção oferece uma variedade de arquivos 7Z para teste, úteis para desenvolvimento e validação de sistemas.</p>)
+    },
+    {
+        title: "Uso Recomendado",
+        type: "usage" as const,
+        content: (<p>✓ Testes de upload de arquivos<br />✓ Validação de processamento de 7Z<br />✓ Testes de integração<br />✓ Verificação de compatibilidade</p>)
+    },
+    {
+        title: "Diferenciais",
+        type: "features" as const,
+        content: (<p>✓ Arquivos de diferentes tamanhos<br />✓ Formatos padronizados<br />✓ Arquivos otimizados para teste</p>)
+    },
+    {
+        title: "Aviso Legal",
+        type: "legal" as const,
+        content: (<p>Estes arquivos são fornecidos apenas para fins de teste. Não utilize em ambientes de produção ou para fins comerciais.</p>)
+    }
+]
+
+export default function SevenZTestFilesPage() {
+    const breadcrumbs = [
+        {
+            name: 'Arquivos de Teste',
+            href: '/arquivos-testes',
+            current: false
+        },
+        {
+            name: '.7Z',
+            href: '/arquivos-testes/7z',
+            current: true
+        }
+    ];
+
+    return (
+        <>
+            <Header
+                miniTitle="Arquivos de Teste"
+                title="Arquivos .7Z para Teste"
+                description="Baixe arquivos .7Z de teste para suas necessidades de desenvolvimento e testes"
+                breadcrumbs={breadcrumbs}
+            />
+            <SevenZTestFiles />
+            <InfoSection items={infoItems} />
+        </>
+    )
+}

--- a/app/arquivos-testes/rar/download/page.tsx
+++ b/app/arquivos-testes/rar/download/page.tsx
@@ -1,0 +1,76 @@
+import { Metadata } from "next";
+import { Suspense } from "react";
+import Header from "@/components/layout/Header";
+import InfoSection from "@/components/layout/template/InfoSection";
+import LoadingResult from "@/components/layout/LoadingResult";
+import DownloadClient from "@/components/layout/files/DownloadClient";
+
+export const metadata: Metadata = {
+    title: "Download Concluído | Arquivos .RAR para Teste - TW Tools",
+    description: "Confirmação de download de arquivo .RAR de teste",
+};
+
+const infoItems = [
+    {
+        title: "Sobre o Download",
+        type: "info" as const,
+        content: (<p>O download do arquivo foi iniciado com sucesso. Verifique sua pasta de downloads.</p>)
+    },
+    {
+        title: "Próximos Passos",
+        type: "usage" as const,
+        content: (<p>✓ Verifique se o arquivo foi baixado corretamente<br />✓ Teste o arquivo em seu ambiente<br />✓ Verifique a integridade do arquivo</p>)
+    },
+    {
+        title: "Dicas de Uso",
+        type: "features" as const,
+        content: (<p>✓ Mantenha os arquivos em uma pasta de teste separada<br />✓ Não use em ambientes de produção<br />✓ Faça backup antes de testar</p>)
+    },
+    {
+        title: "Aviso Legal",
+        type: "legal" as const,
+        content: (<p>Estes arquivos são fornecidos apenas para fins de teste. Não utilize em ambientes de produção ou para fins comerciais.</p>)
+    }
+]
+
+export default function DownloadPage() {
+    const breadcrumbs = [
+        {
+            name: 'Arquivos de Teste',
+            href: '/arquivos-testes',
+            current: false
+        },
+        {
+            name: '.RAR',
+            href: '/arquivos-testes/rar',
+            current: false
+        },
+        {
+            name: 'Download',
+            href: '/arquivos-testes/rar/download',
+            current: true
+        }
+    ];
+
+    return (
+        <>
+            <Header
+                miniTitle="Download Concluído"
+                title="Arquivo .RAR Baixado com Sucesso"
+                description="Seu arquivo .RAR de teste foi baixado com sucesso"
+                breadcrumbs={breadcrumbs}
+            />
+            <Suspense fallback={<LoadingResult />}>
+                <DownloadClient
+                    title="Download Concluído"
+                    description="O arquivo foi baixado com sucesso"
+                    infoTitle="Informações Importantes"
+                    infoMessage="Verifique sua pasta de downloads para encontrar o arquivo"
+                    backPath="/arquivos-testes"
+                    buttonText="Voltar para Lista de Arquivos"
+                />
+            </Suspense>
+            <InfoSection items={infoItems} />
+        </>
+    );
+}

--- a/app/arquivos-testes/rar/page.tsx
+++ b/app/arquivos-testes/rar/page.tsx
@@ -1,0 +1,60 @@
+import { Metadata } from "next";
+import Header from "@/components/layout/Header";
+import InfoSection from "@/components/layout/template/InfoSection";
+import RARTestFiles from "@/components/layout/files/RARTestFiles";
+
+export const metadata: Metadata = {
+    title: "Arquivos .RAR para Teste | TW Tools",
+    description: "Baixe arquivos .RAR de teste para suas necessidades de desenvolvimento e testes",
+};
+
+const infoItems = [
+    {
+        title: "Sobre os Arquivos",
+        type: "info" as const,
+        content: (<p>Esta seção oferece uma variedade de arquivos RAR para teste, úteis para desenvolvimento e validação de sistemas.</p>)
+    },
+    {
+        title: "Uso Recomendado",
+        type: "usage" as const,
+        content: (<p>✓ Testes de upload de arquivos<br />✓ Validação de processamento de RAR<br />✓ Testes de integração<br />✓ Verificação de compatibilidade</p>)
+    },
+    {
+        title: "Diferenciais",
+        type: "features" as const,
+        content: (<p>✓ Arquivos de diferentes tamanhos<br />✓ Formatos padronizados<br />✓ Arquivos otimizados para teste</p>)
+    },
+    {
+        title: "Aviso Legal",
+        type: "legal" as const,
+        content: (<p>Estes arquivos são fornecidos apenas para fins de teste. Não utilize em ambientes de produção ou para fins comerciais.</p>)
+    }
+]
+
+export default function RARTestFilesPage() {
+    const breadcrumbs = [
+        {
+            name: 'Arquivos de Teste',
+            href: '/arquivos-testes',
+            current: false
+        },
+        {
+            name: '.RAR',
+            href: '/arquivos-testes/rar',
+            current: true
+        }
+    ];
+
+    return (
+        <>
+            <Header
+                miniTitle="Arquivos de Teste"
+                title="Arquivos .RAR para Teste"
+                description="Baixe arquivos .RAR de teste para suas necessidades de desenvolvimento e testes"
+                breadcrumbs={breadcrumbs}
+            />
+            <RARTestFiles />
+            <InfoSection items={infoItems} />
+        </>
+    )
+}

--- a/app/arquivos-testes/zip/download/page.tsx
+++ b/app/arquivos-testes/zip/download/page.tsx
@@ -1,0 +1,76 @@
+import { Metadata } from "next";
+import { Suspense } from "react";
+import Header from "@/components/layout/Header";
+import InfoSection from "@/components/layout/template/InfoSection";
+import LoadingResult from "@/components/layout/LoadingResult";
+import DownloadClient from "@/components/layout/files/DownloadClient";
+
+export const metadata: Metadata = {
+    title: "Download Concluído | Arquivos .ZIP para Teste - TW Tools",
+    description: "Confirmação de download de arquivo .ZIP de teste",
+};
+
+const infoItems = [
+    {
+        title: "Sobre o Download",
+        type: "info" as const,
+        content: (<p>O download do arquivo foi iniciado com sucesso. Verifique sua pasta de downloads.</p>)
+    },
+    {
+        title: "Próximos Passos",
+        type: "usage" as const,
+        content: (<p>✓ Verifique se o arquivo foi baixado corretamente<br />✓ Teste o arquivo em seu ambiente<br />✓ Verifique a integridade do arquivo</p>)
+    },
+    {
+        title: "Dicas de Uso",
+        type: "features" as const,
+        content: (<p>✓ Mantenha os arquivos em uma pasta de teste separada<br />✓ Não use em ambientes de produção<br />✓ Faça backup antes de testar</p>)
+    },
+    {
+        title: "Aviso Legal",
+        type: "legal" as const,
+        content: (<p>Estes arquivos são fornecidos apenas para fins de teste. Não utilize em ambientes de produção ou para fins comerciais.</p>)
+    }
+]
+
+export default function DownloadPage() {
+    const breadcrumbs = [
+        {
+            name: 'Arquivos de Teste',
+            href: '/arquivos-testes',
+            current: false
+        },
+        {
+            name: '.ZIP',
+            href: '/arquivos-testes/zip',
+            current: false
+        },
+        {
+            name: 'Download',
+            href: '/arquivos-testes/zip/download',
+            current: true
+        }
+    ];
+
+    return (
+        <>
+            <Header
+                miniTitle="Download Concluído"
+                title="Arquivo .ZIP Baixado com Sucesso"
+                description="Seu arquivo .ZIP de teste foi baixado com sucesso"
+                breadcrumbs={breadcrumbs}
+            />
+            <Suspense fallback={<LoadingResult />}>
+                <DownloadClient
+                    title="Download Concluído"
+                    description="O arquivo foi baixado com sucesso"
+                    infoTitle="Informações Importantes"
+                    infoMessage="Verifique sua pasta de downloads para encontrar o arquivo"
+                    backPath="/arquivos-testes"
+                    buttonText="Voltar para Lista de Arquivos"
+                />
+            </Suspense>
+            <InfoSection items={infoItems} />
+        </>
+    );
+}

--- a/app/arquivos-testes/zip/page.tsx
+++ b/app/arquivos-testes/zip/page.tsx
@@ -1,0 +1,60 @@
+import { Metadata } from "next";
+import Header from "@/components/layout/Header";
+import InfoSection from "@/components/layout/template/InfoSection";
+import ZIPTestFiles from "@/components/layout/files/ZIPTestFiles";
+
+export const metadata: Metadata = {
+    title: "Arquivos .ZIP para Teste | TW Tools",
+    description: "Baixe arquivos .ZIP de teste para suas necessidades de desenvolvimento e testes",
+};
+
+const infoItems = [
+    {
+        title: "Sobre os Arquivos",
+        type: "info" as const,
+        content: (<p>Esta seção oferece uma variedade de arquivos ZIP para teste, úteis para desenvolvimento e validação de sistemas.</p>)
+    },
+    {
+        title: "Uso Recomendado",
+        type: "usage" as const,
+        content: (<p>✓ Testes de upload de arquivos<br />✓ Validação de processamento de ZIP<br />✓ Testes de integração<br />✓ Verificação de compatibilidade</p>)
+    },
+    {
+        title: "Diferenciais",
+        type: "features" as const,
+        content: (<p>✓ Arquivos de diferentes tamanhos<br />✓ Formatos padronizados<br />✓ Arquivos otimizados para teste</p>)
+    },
+    {
+        title: "Aviso Legal",
+        type: "legal" as const,
+        content: (<p>Estes arquivos são fornecidos apenas para fins de teste. Não utilize em ambientes de produção ou para fins comerciais.</p>)
+    }
+]
+
+export default function ZIPTestFilesPage() {
+    const breadcrumbs = [
+        {
+            name: 'Arquivos de Teste',
+            href: '/arquivos-testes',
+            current: false
+        },
+        {
+            name: '.ZIP',
+            href: '/arquivos-testes/zip',
+            current: true
+        }
+    ];
+
+    return (
+        <>
+            <Header
+                miniTitle="Arquivos de Teste"
+                title="Arquivos .ZIP para Teste"
+                description="Baixe arquivos .ZIP de teste para suas necessidades de desenvolvimento e testes"
+                breadcrumbs={breadcrumbs}
+            />
+            <ZIPTestFiles />
+            <InfoSection items={infoItems} />
+        </>
+    )
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -96,6 +96,9 @@ export const arquivosRoutes = {
     { name: 'Arquivos .CSV', href: '/arquivos-testes/csv' },
     { name: 'Arquivos .JSON', href: '/arquivos-testes/json' },
     { name: 'Arquivos .TXT', href: '/arquivos-testes/txt' },
+    { name: 'Arquivos .ZIP', href: '/arquivos-testes/zip' },
+    { name: 'Arquivos .RAR', href: '/arquivos-testes/rar' },
+    { name: 'Arquivos .7Z', href: '/arquivos-testes/7z' },
     { name: 'Todos os Arquivos', href: '/arquivos-testes', shortcutHidden: true },
   ],
 }

--- a/src/components/layout/files/RARTestFiles.tsx
+++ b/src/components/layout/files/RARTestFiles.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import Button from '@/components/ui/Button'
+import FormPage from '../template/FormPage'
+
+const rarFiles = [
+    {
+        id: 'sample1',
+        name: 'RAR de Exemplo 1',
+        description: 'Arquivo RAR simples',
+        size: '95 B',
+        fileName: 'file01.rar',
+        base64:
+            'UmFyIRoHAQAzkrXlCgEFBgAFAQGAgAB9UAQXKgIDC5EABJEApIMCk8m3EYAAAQx0bXAvdGVzdC50eHQKAxNLB51oKpjsHEFycXVpdm8gZGUgdGVzdGUKHXdWUQMFBAA='
+    },
+]
+
+export default function RARTestFiles() {
+    const router = useRouter()
+
+    const handleDownload = (file: typeof rarFiles[0]) => {
+        router.push(`/arquivos-testes/rar/download`)
+        setTimeout(() => {
+            const link = document.createElement('a')
+            link.href = `data:application/vnd.rar;base64,${file.base64}`
+            link.download = file.fileName
+            link.click()
+        }, 100)
+    }
+
+    return (
+        <FormPage
+            title="Arquivos RAR Disponíveis"
+            description="Selecione um arquivo para download"
+        >
+            <div className="px-4 py-6 sm:p-8">
+                <div className="grid grid-cols-1 gap-6">
+                    {rarFiles.map((file) => (
+                        <div
+                            key={file.id}
+                            className="flex items-center justify-between p-4 border-main-900 border rounded-lg hover:bg-gray-50"
+                        >
+                            <div>
+                                <h3 className="text-lg font-medium text-gray-900">{file.name}</h3>
+                                <p className="mt-1 text-sm text-gray-500">{file.description}</p>
+                                <p className="mt-1 text-sm text-gray-500">Tamanho: {file.size}</p>
+                            </div>
+
+                            <Button
+                                onClick={() => handleDownload(file)}
+                            >
+                                Download
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </FormPage>
+    )
+}

--- a/src/components/layout/files/SevenZTestFiles.tsx
+++ b/src/components/layout/files/SevenZTestFiles.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import Button from '@/components/ui/Button'
+import FormPage from '../template/FormPage'
+
+const sevenZFiles = [
+    {
+        id: 'sample1',
+        name: '7Z de Exemplo 1',
+        description: 'Arquivo 7Z simples',
+        size: '143 B',
+        fileName: 'file01.7z',
+        base64:
+            'N3q8ryccAARkNSg0FQAAAAAAAABaAAAAAAAAACZ1ZJABABBBcnF1aXZvIGRlIHRlc3RlCgABBAYAQkVAAcLAQABISEBAAwRAAgKAZPJtxEAAAUBGQwAAAAAAAAAAAAAAAAREwB0AGUAcwB0AC4AdAB4AHQAAAAZABQKAQBCI9p6mwzcARUGAQAggKSBAAA='
+    },
+]
+
+export default function SevenZTestFiles() {
+    const router = useRouter()
+
+    const handleDownload = (file: typeof sevenZFiles[0]) => {
+        router.push(`/arquivos-testes/7z/download`)
+        setTimeout(() => {
+            const link = document.createElement('a')
+            link.href = `data:application/x-7z-compressed;base64,${file.base64}`
+            link.download = file.fileName
+            link.click()
+        }, 100)
+    }
+
+    return (
+        <FormPage
+            title="Arquivos 7Z Disponíveis"
+            description="Selecione um arquivo para download"
+        >
+            <div className="px-4 py-6 sm:p-8">
+                <div className="grid grid-cols-1 gap-6">
+                    {sevenZFiles.map((file) => (
+                        <div
+                            key={file.id}
+                            className="flex items-center justify-between p-4 border-main-900 border rounded-lg hover:bg-gray-50"
+                        >
+                            <div>
+                                <h3 className="text-lg font-medium text-gray-900">{file.name}</h3>
+                                <p className="mt-1 text-sm text-gray-500">{file.description}</p>
+                                <p className="mt-1 text-sm text-gray-500">Tamanho: {file.size}</p>
+                            </div>
+
+                            <Button
+                                onClick={() => handleDownload(file)}
+                            >
+                                Download
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </FormPage>
+    )
+}

--- a/src/components/layout/files/ZIPTestFiles.tsx
+++ b/src/components/layout/files/ZIPTestFiles.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import Button from '@/components/ui/Button'
+import FormPage from '../template/FormPage'
+
+const zipFiles = [
+    {
+        id: 'sample1',
+        name: 'ZIP de Exemplo 1',
+        description: 'Arquivo ZIP simples',
+        size: '183 B',
+        fileName: 'file01.zip',
+        base64:
+            'UEsDBAoAAAAAAJatDVuTybcREQAAABEAAAAIABwAdGVzdC50eHRVVAkAA0sHnWhLB51odXgLAAEEAAAAAAQAAAAAQXJxdWl2byBkZSB0ZXN0ZQpQSwECHgMKAAAAAACWrQ1bk8m3EREAAAARAAAACAAYAAAAAAABAAAApIEAAAAAdGVzdC50eHRVVAUAA0sHnWh1eAsAAQQAAAAABAAAAABQSwUGAAAAAAEAAQBOAAAAUwAAAAAA'
+    },
+]
+
+export default function ZIPTestFiles() {
+    const router = useRouter()
+
+    const handleDownload = (file: typeof zipFiles[0]) => {
+        router.push(`/arquivos-testes/zip/download`)
+        setTimeout(() => {
+            const link = document.createElement('a')
+            link.href = `data:application/zip;base64,${file.base64}`
+            link.download = file.fileName
+            link.click()
+        }, 100)
+    }
+
+    return (
+        <FormPage
+            title="Arquivos ZIP Disponíveis"
+            description="Selecione um arquivo para download"
+        >
+            <div className="px-4 py-6 sm:p-8">
+                <div className="grid grid-cols-1 gap-6">
+                    {zipFiles.map((file) => (
+                        <div
+                            key={file.id}
+                            className="flex items-center justify-between p-4 border-main-900 border rounded-lg hover:bg-gray-50"
+                        >
+                            <div>
+                                <h3 className="text-lg font-medium text-gray-900">{file.name}</h3>
+                                <p className="mt-1 text-sm text-gray-500">{file.description}</p>
+                                <p className="mt-1 text-sm text-gray-500">Tamanho: {file.size}</p>
+                            </div>
+
+                            <Button
+                                onClick={() => handleDownload(file)}
+                            >
+                                Download
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </FormPage>
+    )
+}


### PR DESCRIPTION
## Summary
- replace binary .zip, .rar, and .7z samples with base64-encoded content
- generate archive downloads client-side via data URLs to avoid storing binaries
- keep test file pages and sidebar routes for ZIP, RAR, and 7Z

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*


------
https://chatgpt.com/codex/tasks/task_e_689d06bf2bcc832295fabcb88120b2f6